### PR TITLE
Half-fix: posts not being responsive

### DIFF
--- a/static/css/post.css
+++ b/static/css/post.css
@@ -56,6 +56,11 @@
   border-radius: 0.5rem;
 }
 
+.highlight > pre > code {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 pre {
   padding: 10px;
   width: inherit;


### PR DESCRIPTION
In response to issue #21.
This is caused by the block of code refusing to wrap the text inside it.
I half-fixed the problem by making the block of code flex-wrap, but for long strings of text such as filters, it doesn't cut them to adapt to the page. I really don't know how I can do that though...